### PR TITLE
Support for Django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 env:
   - DJANGO_VERSION=1.8.0
   - DJANGO_VERSION=1.9.0
+  - DJANGO_VERSION=1.10.6
 install:
   - pip install -q Django~=$DJANGO_VERSION --use-mirrors
   - pip install -r requirements_test.txt

--- a/mangopay/models.py
+++ b/mangopay/models.py
@@ -1,6 +1,10 @@
 import urllib2
 import base64
-import jsonfield
+try:
+    from jsonfield import JSONField
+except ImportError:
+    from django.contrib.postgres.fields import JSONField
+
 from datetime import datetime
 from decimal import Decimal, ROUND_FLOOR
 
@@ -514,7 +518,7 @@ class MangoPayPayIn(models.Model):
 
     # Pay in via bank wire
     wire_reference = models.CharField(null=True, blank=True, max_length=50)
-    mangopay_bank_account = jsonfield.JSONField(null=True, blank=True)
+    mangopay_bank_account = JSONField(null=True, blank=True)
 
     def _get_payment_details(self):
         raise NotImplemented

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ django-model-utils==1.4.0
 django-storages==1.1.8
 requests==2.2.1
 requests-oauthlib==0.6.1
-django-jsonfield==1.0.0
+django-jsonfield==1.0.1
 django-filepicker==0.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ django-model-utils==1.4.0
 django-storages==1.1.8
 requests==2.2.1
 requests-oauthlib==0.6.1
-django-jsonfield==0.9.15
+django-jsonfield==1.0.0
 django-filepicker==0.2.2


### PR DESCRIPTION
How can we control the installation of  django-jsonfield on Django versions < 1.9 and just use the Django JSONField from versions > 1.9.

Not completely convinced at my models.py approach. 

All tests passing.